### PR TITLE
Enhance text and links

### DIFF
--- a/app/static/css/invite.css
+++ b/app/static/css/invite.css
@@ -39,11 +39,12 @@ body {
 }
 
 .invite span a {
-  color: grey;
+  color: grey; /* fallback */
+  color: rgba(255, 255, 255, .6);
 }
 
 .invite span a:hover {
-  color: #DD2C00;
+  color: #FF5722;
 }
 
 .invite .submit {
@@ -72,14 +73,16 @@ footer li {
   list-style: none;
   vertical-align: middle;
   line-height: normal;
+  color: rgba(255, 255, 255, 0.54);
 }
 
 footer a {
-  color: grey
+  color: grey; /* fallback */
+  color: rgba(255, 255, 255, .6);
 }
 
 footer a:hover {
-  color: #DD2C00;
+  color: #FF5722;
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
Make grey text (links too) white with 0.6 alpha value, and make link hover color #FF5722.

The text being grey didn't look all that well everywhere. With some transparency, it looks great on every color.
